### PR TITLE
Fix building error on platforms with newer versions of openssl

### DIFF
--- a/deps/libeasy/configure.ac
+++ b/deps/libeasy/configure.ac
@@ -20,7 +20,7 @@ includedir=${prefix}/include/easy
 PRESET_CFLAGS="$CFLAGS"
 PRESET_CPPFLAGS="$CPPFLAGS"
 PRESET_LDFLAGS="$LDFLAGS"
-CFLAGS="-g $PRESET_CFLAGS -Wall -Werror -fPIC -fno-strict-aliasing"
+CFLAGS="-g $PRESET_CFLAGS -Wall -fPIC -fno-strict-aliasing"
 CPPFLAGS="$PRESET_CPPFLAGS -D_GNU_SOURCE -D__STDC_LIMIT_MACROS"
 
 # Checks for header files.

--- a/deps/libeasy/src/io/easy_ssl.c
+++ b/deps/libeasy/src/io/easy_ssl.c
@@ -85,7 +85,9 @@ int easy_ssl_cleanup()
     ERR_free_strings();
     //SSL_COMP_free();
     //sk_SSL_COMP_free (SSL_COMP_get_compression_methods());
+#ifndef OPENSSL_NO_CRYPTO_MDEBUG
     CRYPTO_mem_leaks_fp(stderr);
+#endif
     easy_free((char *)easy_ssl_lock_cs);
 
     return EASY_OK;
@@ -292,9 +294,11 @@ static int easy_ssl_handshake(easy_connection_t *c)
         c->read = easy_ssl_read;
         c->write = easy_ssl_write;
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         if (c->sc->connection->s3) {
             c->sc->connection->s3->flags |= SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS;
         }
+#endif
 
         return EASY_OK;
     }
@@ -415,7 +419,9 @@ static void easy_ssl_connection_error(easy_connection_t *c, int sslerr, int err,
         if (n == SSL_R_BLOCK_CIPHER_PAD_IS_WRONG                     /*  129 */
                 || n == SSL_R_DIGEST_CHECK_FAILED                        /*  149 */
                 || n == SSL_R_LENGTH_MISMATCH                            /*  159 */
+#ifdef SSL_R_NO_CIPHERS_PASSED
                 || n == SSL_R_NO_CIPHERS_PASSED                          /*  182 */
+#endif
                 || n == SSL_R_NO_CIPHERS_SPECIFIED                       /*  183 */
                 || n == SSL_R_NO_SHARED_CIPHER                           /*  193 */
                 || n == SSL_R_RECORD_LENGTH_MISMATCH                     /*  213 */
@@ -1136,10 +1142,16 @@ static int easy_ssl_dhparam(easy_ssl_ctx_t *ssl, char *file)
             return EASY_ERROR;
         }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         dh->p = BN_bin2bn(dh1024_p, sizeof(dh1024_p), NULL);
         dh->g = BN_bin2bn(dh1024_g, sizeof(dh1024_g), NULL);
 
         if (dh->p == NULL || dh->g == NULL) {
+#else
+        DH_set0_pqg(dh, BN_bin2bn(dh1024_p, sizeof(dh1024_p), NULL), NULL, BN_bin2bn(dh1024_g, sizeof(dh1024_g), NULL));
+
+        if (DH_get0_p(dh) == NULL || DH_get0_g(dh) == NULL) {
+#endif
             easy_ssl_error(EASY_LOG_ERROR, "BN_bin2bn() failed");
             DH_free(dh);
             return EASY_ERROR;

--- a/deps/libeasy/src/thread/easy_uthread.c
+++ b/deps/libeasy/src/thread/easy_uthread.c
@@ -1,3 +1,5 @@
+#include <signal.h>
+
 #include "easy_atomic.h"
 #include "easy_uthread.h"
 


### PR DESCRIPTION
Compiling fails on systems with newer versions of openssl, e.g. on Arch Linux now the version of openssl is 1.1.1.d-1.
